### PR TITLE
feat: add views and initialView configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,21 @@ Sets the number of days to show in the list tab. Defaults to 28. Only used with 
 `custom_list_button="list"` \
 Sets the label for the listCustom button. Defaults to "list".
 
+`views="dayGridMonth, listCustom"` \
+Sets the view types available. If only one view is provided, no view switch buttons will be shown. Defaults to `dayGridMonth, listCustom`.
+
+`initial_view="dayGridMonth"` \
+Sets the default view to be displayed when opening the page. Defaults to `dayGridMonth`.
+
+`enforce_listview_on_mobile="true"` \
+Sets the change to the list view behavior on small screens. Options: `true` and `false`. Defaults to `true`. This option has no effect if there is no list view declared in the `views` option.
+
+`show_today_button="true"` \
+Sets the visibility of the `Today` button. Options: `true` and `false`. Defaults to `true`.
+
+`show_title="true"` \
+Sets the visibility of the calendar `title`. Options: `true` and `false`. Defaults to `true`.
+
 ### Obtaining Google Calendar API Key
 
 1. Go to the Google Developer Console and create a new project (it might take a second).

--- a/init/shortcode.php
+++ b/init/shortcode.php
@@ -10,17 +10,17 @@ function pgcal_shortcode($atts) {
 
 	$args = shortcode_atts(
 		array(
-			'gcal'                => "",
-			// 'locale'              => $locale,
-			'locale'              => "en",
-			'list_type'           => "listCustom", // listDay, listWeek, listMonth, and listYear also day, week, month, and year
-			'custom_list_button'  => "list",
-			'custom_days'         => "28",
-			'views' => 'dayGridMonth, listCustom',
-			'initial_view' => 'dayGridMonth',
-			'enforce_listview_on_mobile' => 'true',
-			'show_today_button' => 'true',
-			'show_title' => 'true',
+			'gcal'                       => "",
+			// 'locale'                     => $locale,
+			'locale'                     => "en",
+			'list_type'                  => "listCustom", // listDay, listWeek, listMonth, and listYear also day, week, month, and year
+			'custom_list_button'         => "list",
+			'custom_days'                => "28",
+			'views'                      => "dayGridMonth, listCustom",
+			'initial_view'               => "dayGridMonth",
+			'enforce_listview_on_mobile' => "true",
+			'show_today_button'          => "true",
+			'show_title'                 => "true",
 		),
 		$atts
 	);

--- a/init/shortcode.php
+++ b/init/shortcode.php
@@ -16,6 +16,11 @@ function pgcal_shortcode($atts) {
 			'list_type'           => "listCustom", // listDay, listWeek, listMonth, and listYear also day, week, month, and year
 			'custom_list_button'  => "list",
 			'custom_days'         => "28",
+			'views' => 'dayGridMonth, listCustom',
+			'initial_view' => 'dayGridMonth',
+			'enforce_listview_on_mobile' => 'true',
+			'show_today_button' => 'true',
+			'show_title' => 'true',
 		),
 		$atts
 	);
@@ -45,7 +50,6 @@ function pgcal_shortcode($atts) {
 
 	// Pass PHP data to script(s)
 	wp_localize_script('pgcal_loader', 'pgcalSettings', $pgcalSettings);
-
 
 	return "
       <div id='pgcalendar'>loading...</div>

--- a/public/js/helpers.js
+++ b/public/js/helpers.js
@@ -1,3 +1,77 @@
+
+/**
+ * Computes all variables related to views
+ *
+ * @param {array} settings Settings received from the shortcode parameters
+ * @returns object
+ */
+const pgcal_resolve_views = (settings) => {
+  const gridViews = ["dayGridMonth"]
+  const listViews = ["listDay", "listWeek", "listMonth", "listYear", "listCustom"];
+  const allowedViews = [...listViews, ...gridViews]
+
+  const wantsToEnforceListviewOnMobile = pgcal_is_truthy(
+    settings["enforce_listview_on_mobile"]
+  )
+
+  let initialView = 'dayGridMonth'
+
+  if (allowedViews.includes(settings['initial_view'])) {
+    initialView = settings['initial_view']
+  }
+
+  const viewsArray = pgcal_csv_to_array(settings["views"])
+  const viewsIncludesList = pgcal_get_item_by_fuzzy_value(viewsArray, 'list')
+  const listType = pgcal_get_item_by_fuzzy_value(viewsArray, settings["list_type"]);
+
+  if (pgcal_is_mobile() && wantsToEnforceListviewOnMobile) {
+    initialView = listType
+  }
+
+  const views = {
+    all: viewsArray,
+    length: viewsArray.length,
+    hasList: !!viewsIncludesList,
+    listType,
+    initial: initialView,
+    wantsToEnforceListviewOnMobile,
+  }
+
+  return views
+}
+
+/**
+ * Tests if the given array has the value in any part of each item
+ *
+ * @param {string} csv Array to be tested
+ * @returns array
+ */
+const pgcal_csv_to_array = (csv) => csv
+  .split(',')
+  .map(view => view.trim())
+
+/**
+ * Tests if the given array has the value in any part of each item
+ *
+ * @param {array} array Array to be tested
+ * @param {string} value String to be checked
+ * @returns boolean
+ */
+const pgcal_get_item_by_fuzzy_value = (array, value) => array.find(
+  item => item.toLowerCase().includes(value.toLowerCase())
+)
+
+/**
+ * Tests if a value is truthy
+ *
+ * @param {string} value String to be tested
+ * @returns boolean
+ */
+function pgcal_is_truthy(value) {
+  const lowercaseValue = (typeof value === 'string') ? value.toLowerCase() : value
+  return ['true', '1', true, 1].includes(lowercaseValue);
+}
+
 /**
  * Tests whether the window size is equal to or less than 768... an arbitrary
  * standard for what is mobile...

--- a/public/js/helpers.js
+++ b/public/js/helpers.js
@@ -6,26 +6,26 @@
  * @returns object
  */
 const pgcal_resolve_views = (settings) => {
-  const gridViews = ["dayGridMonth"]
+  const gridViews = ["dayGridMonth"];
   const listViews = ["listDay", "listWeek", "listMonth", "listYear", "listCustom"];
-  const allowedViews = [...listViews, ...gridViews]
+  const allowedViews = [...listViews, ...gridViews];
 
   const wantsToEnforceListviewOnMobile = pgcal_is_truthy(
     settings["enforce_listview_on_mobile"]
-  )
+  );
 
-  let initialView = 'dayGridMonth'
+  let initialView = "dayGridMonth";
 
-  if (allowedViews.includes(settings['initial_view'])) {
-    initialView = settings['initial_view']
+  if (allowedViews.includes(settings["initial_view"])) {
+    initialView = settings["initial_view"];
   }
 
-  const viewsArray = pgcal_csv_to_array(settings["views"])
-  const viewsIncludesList = pgcal_get_item_by_fuzzy_value(viewsArray, 'list')
+  const viewsArray = pgcal_csv_to_array(settings["views"]);
+  const viewsIncludesList = pgcal_get_item_by_fuzzy_value(viewsArray, "list");
   const listType = pgcal_get_item_by_fuzzy_value(viewsArray, settings["list_type"]);
 
   if (pgcal_is_mobile() && wantsToEnforceListviewOnMobile) {
-    initialView = listType
+    initialView = listType;
   }
 
   const views = {
@@ -35,9 +35,9 @@ const pgcal_resolve_views = (settings) => {
     listType,
     initial: initialView,
     wantsToEnforceListviewOnMobile,
-  }
+  };
 
-  return views
+  return views;
 }
 
 /**
@@ -47,8 +47,8 @@ const pgcal_resolve_views = (settings) => {
  * @returns array
  */
 const pgcal_csv_to_array = (csv) => csv
-  .split(',')
-  .map(view => view.trim())
+  .split(",")
+  .map(view => view.trim());
 
 /**
  * Tests if the given array has the value in any part of each item
@@ -59,7 +59,7 @@ const pgcal_csv_to_array = (csv) => csv
  */
 const pgcal_get_item_by_fuzzy_value = (array, value) => array.find(
   item => item.toLowerCase().includes(value.toLowerCase())
-)
+);
 
 /**
  * Tests if a value is truthy
@@ -68,8 +68,8 @@ const pgcal_get_item_by_fuzzy_value = (array, value) => array.find(
  * @returns boolean
  */
 function pgcal_is_truthy(value) {
-  const lowercaseValue = (typeof value === 'string') ? value.toLowerCase() : value
-  return ['true', '1', true, 1].includes(lowercaseValue);
+  const lowercaseValue = (typeof value === "string") ? value.toLowerCase() : value;
+  return ["true", "1", true, 1].includes(lowercaseValue);
 }
 
 /**

--- a/public/js/pgcal.js
+++ b/public/js/pgcal.js
@@ -10,6 +10,16 @@ document.addEventListener("DOMContentLoaded", function () {
   // console.log(':: views')
   // console.table(views)
 
+  const toolbarLeft = pgcal_is_truthy(pgcalSettings["show_today_button"])
+    ? "prev,next today"
+    : "prev,next"
+  const toolbarCenter = pgcal_is_truthy(pgcalSettings["show_title"])
+    ? "title"
+    : ""
+  const toolbarRight = views.length > 1
+    ? views.all.join(',')
+    : ""
+
   let selectedView = views.initial
 
   const calendar = new FullCalendar.Calendar(calendarEl, {

--- a/readme.txt
+++ b/readme.txt
@@ -58,6 +58,21 @@ Sets the number of days to show in the list tab. Defaults to 28. Only used with 
 `custom_list_button="list"`
 Sets the label for the listCustom button. Defaults to "list".
 
+`views="dayGridMonth, listCustom"`
+Sets the view types available. If only one view is provided, no view switch buttons will be shown. Defaults to "dayGridMonth, listCustom".
+
+`initial_view="dayGridMonth"`
+Sets the default view to be displayed when opening the page. Defaults to "dayGridMonth".
+
+`enforce_listview_on_mobile="true"`
+Sets the change to the list view behavior on small screens. Options: "true" and "false". Defaults to "true". This option has no effect if there is no list view declared in the "views" option.
+
+`show_today_button="true"`
+Sets the visibility of the "Today" button. Options: "true" and "false". Defaults to "true".
+
+`show_title="true"`
+Sets the visibility of the calendar title. Options: "true" and "false". Defaults to "true".
+
 **Obtaining Google Calendar API Key**
 
 1. Go to the Google Developer Console and create a new project (it might take a second).


### PR DESCRIPTION
- all current default settings were kept
- add 3 new shortcode parameters (views, initial_view and enforce_listview_on_mobile)
- allow to choose view types and the initialView
- all view types are shown as buttons
- allow title and today buttons to be hidden
- change the list view on mobile to optional

Resolves #5 